### PR TITLE
Update the version of concat to use, does not work with v1.0.0

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,3 +8,4 @@ description   ''
 project_page  'https://github.com/gdhbashton/puppet-consul_template'
 
 dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/concat', '>= 1.1.0'

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.1.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 0.4.0" }
   ]
 }


### PR DESCRIPTION
Tested with concat v1.0.0 and the module failed to render config.json correctly. Newer version of concat works fine.
