### PR TITLE
Do not require that a template file is passed to consul_template::watch

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -4,17 +4,19 @@
 # This is a single instance of a configuration file to watch
 # for changes in Consul and update the local file
 define consul_template::watch (
-  $template,
+  $template = undef,
   $destination,
   $command,
 ) {
   include consul_template
 
-  file { "${consul_template::config_dir}/${name}.ctmpl":
-    ensure  => present,
-    content => template($template),
-  } ->
-
+  if $template != undef {
+    file { "${consul_template::config_dir}/${name}.ctmpl":
+      ensure  => present,
+      content => template($template),
+      before  => Concat::Fragment["${name}.ctmpl"],
+    }
+  }
   concat::fragment { "${name}.ctmpl":
     target  => 'consul-template/config.json',
     content => "template {\n  source = \"${consul_template::config_dir}/${name}.ctmpl\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n}\n\n",


### PR DESCRIPTION
This change allows for other modules to manage the consul template file. For example, I wanted to use an existing module (haproxy) to write the ctmpl file.
