### PR TITLE
Ensure resource ordering, regardless of boolean states. 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,6 +2,9 @@
 #
 class consul_template::install {
 
+  User<| |> -> Group<| |>
+  Group<| |> -> File<| |>
+
   if $consul_template::data_dir {
     file { $consul_template::data_dir:
       ensure => 'directory',


### PR DESCRIPTION
User/Group ordering causes errors rarely without this, due to the semi-random manner in which Puppet orders things. If the group gets created before the user, the user create will fail. Can't put direct require/before tags in the entities though, due to the if statements on management, thus we just use resource ordering. I added in the File bit so that the file resource that depends on the user/group ensures they exist first (that can also cause ordering issues). 
