### PR TITLE
Fixing a bit of an overzealous change

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 #
 class consul_template::install {
 
-  User<| |> -> Group<| |>
+  User<| |> -> File<| |>
   Group<| |> -> File<| |>
 
   if $consul_template::data_dir {


### PR DESCRIPTION
The PR I put in earlier can cause issues with unrelated groups that require users to exist first. Since the only thing that matters here is that users and groups must be established before files, this change is less error-prone. My apologies for any issues the first one may have caused.
