### PR TITLE
Logging params

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,13 @@ class consul_template::config (
     order   => '00',
   }
 
+  # Set the log level
+  concat::fragment { 'log_level':
+    target  => 'consul-template/config.json',
+    content => inline_template("log_level = \"${::consul_template::log_level}\"\n"),
+    order   => '01'
+  }
+
   file { $consul_template::config_dir:
     ensure  => 'directory',
     purge   => $purge,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,7 @@ class consul_template::config (
     order   => '01'
   }
 
+
   file { $consul_template::config_dir:
     ensure  => 'directory',
     purge   => $purge,


### PR DESCRIPTION
Added log_level to main consul-template config. At present this was only being set in the sysv init script and not used elsewhere. Setting it in the main config file means it can be shared across all platforms.
