### PR TITLE
Add data_dir, manage_{user,group} as optional parameters in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,12 @@
 #
 # [*data_dir*]
 #   Path to a directory to create to hold some data. Defaults to ''
+#
+# [*manage_user*]
+#   Name of a user to create if it does not exist. Defaults to ''
+#
+# [*manage_group*]
+#   Name of a group to create if it does not exist. Defaults to ''
 
 class consul_template (
   $purge_config_dir  = true,
@@ -78,6 +84,8 @@ class consul_template (
   $vault_ssl_cert    = '',
   $vault_ssl_ca_cert = '',
   $data_dir          = '',
+  $manage_user       = '',
+  $manage_group      = '',
 ) inherits ::consul_template::params {
 
   validate_bool($purge_config_dir)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,9 @@
 #
 # [*vault_ssl_ca_cert*]
 #   What is the path to the ca cert.pem
+#
+# [*data_dir*]
+#   Path to a directory to create to hold some data. Defaults to ''
 
 class consul_template (
   $purge_config_dir  = true,
@@ -74,6 +77,7 @@ class consul_template (
   $vault_ssl_verify  = true,
   $vault_ssl_cert    = '',
   $vault_ssl_ca_cert = '',
+  $data_dir          = '',
 ) inherits ::consul_template::params {
 
   validate_bool($purge_config_dir)


### PR DESCRIPTION
consul_template::install requires some variables to work properly. However, the class takes no parameters. By adding them as optional parameters in init.pp, they can be passed in directly or via Hiera.

Currently, there are no tests for this class. A simple 'it { is_expected.to compile }' will unearth the problem. The trickier part of writing a test is that the class operates under the assumption that consul_template will be executed first, and that consul_template will include consul_template::install. This makes it difficult to write a spec that directly tests consul_template::install.
