### PR TITLE
Make Service['consul-template'] Refresh on ctmpl template change

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -16,6 +16,7 @@ define consul_template::watch (
       ensure  => present,
       content => template($template),
       before  => Concat::Fragment["${name}.ctmpl"],
+      notify  => Service['consul-template'],
     }
   }
   concat::fragment { "${name}.ctmpl":


### PR DESCRIPTION
manifests/watch.pp is set to notify the Service['consul-template'] when consul-template/config.json changes. However, this file will only change when a ctmpl file is added, removed, or the destination/command is changed. The config.json file does not change if the erb template for the ctmpl file is modified.

Note: I have not tested this change yet, but I believe it should work. I will test it within the next day and comment with my results.
