### PR TITLE
Use directory (instead of single file) for configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,13 +57,13 @@ class consul_template::config (
     }
   }
 
-  file { $consul_template::config_dir:
+  file { [$consul_template::config_dir, "${consul_template::config_dir}/config"]:
     ensure  => 'directory',
     purge   => $purge,
     recurse => $purge,
   } ->
   concat { 'consul-template/config.json':
-    path   => "${consul_template::config_dir}/config.json",
+    path   => "${consul_template::config_dir}/config/config.json",
     notify => Service['consul-template'],
   }
 

--- a/templates/consul-template.debian.erb
+++ b/templates/consul-template.debian.erb
@@ -17,7 +17,7 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin:<%= scope.lookupvar('consul_template::bin_dir
 DESC="Consul Template KV file populater"
 NAME=consul-template
 DAEMON=<%= scope.lookupvar('consul_template::bin_dir') %>/$NAME
-DAEMON_ARGS="-config <%= scope.lookupvar('consul_template::config_dir') %>/config.json <%= scope.lookupvar('consul_template::extra_options') %>"
+DAEMON_ARGS="-config <%= scope.lookupvar('consul_template::config_dir') %>/config <%= scope.lookupvar('consul_template::extra_options') %>"
 USER=<%= scope.lookupvar('consul_template::user') %>
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME

--- a/templates/consul-template.systemd.erb
+++ b/templates/consul-template.systemd.erb
@@ -5,7 +5,7 @@ After=basic.target network.target
 
 [Service]
 ExecStart=<%= scope.lookupvar('consul_template::bin_dir') %>/consul-template \
-  -config <%= scope.lookupvar('consul_template::config_dir') %>/config.json <%= scope.lookupvar('consul_template::extra_options') %>
+  -config <%= scope.lookupvar('consul_template::config_dir') %>/config <%= scope.lookupvar('consul_template::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure

--- a/templates/consul-template.sysv.erb
+++ b/templates/consul-template.sysv.erb
@@ -12,7 +12,7 @@
 
 NAME="consul-template"
 CONSUL_TEMPLATE=<%= scope.lookupvar('consul_template::bin_dir') %>/consul-template
-CONFIG=<%= scope.lookupvar('consul_template::config_dir') %>/config.json
+CONFIG=<%= scope.lookupvar('consul_template::config_dir') %>/config
 OPTIONS=<%= scope.lookupvar('consul_template::extra_options') %>
 LOGLEVEL=<%= scope.lookupvar('consul_template::log_level') %>
 CMD="${CONSUL_TEMPLATE} -config ${CONFIG} ${OPTIONS}"

--- a/templates/consul-template.upstart.erb
+++ b/templates/consul-template.upstart.erb
@@ -8,7 +8,7 @@ env CONFIG=<%= scope.lookupvar('consul_template::config_dir') %>
 
 
 script
-    exec $CONSUL -config $CONFIG/config.json <%= scope.lookupvar('consul_template::extra_options') %>
+    exec $CONSUL -config $CONFIG/config <%= scope.lookupvar('consul_template::extra_options') %>
 end script
 
 respawn


### PR DESCRIPTION
This makes consul-template read its configuration files from a directory instead of just the `config.json` file. The only change in existing behavior is the exact path of the config file (which was moved to a subdirectory). 

The use case for this is letting configuration be added independently of this module. Specifically it's useful to allow another process to provide the Vault address and token. 
