### PR TITLE
Fixed checks if variables are defined, fixed variable naming

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,11 +2,11 @@
 #
 class consul_template::install {
 
-  if $consul_template::data_dir {
+  if ! empty($consul_template::data_dir) {
     file { $consul_template::data_dir:
       ensure => 'directory',
-      owner  => $consul_template::user,
-      group  => $consul_template::group,
+      owner  => $consul_template::manage_user,
+      group  => $consul_template::manage_group,
       mode   => '0755',
     }
   }
@@ -96,13 +96,13 @@ class consul_template::install {
     }
   }
 
-  if $consul_template::manage_user {
-    user { $consul_template::user:
+  if ! empty($consul_template::manage_user) {
+    user { $consul_template::manage_user:
       ensure => 'present',
     }
   }
-  if $consul_template::manage_group {
-    group { $consul_template::group:
+  if ! empty($consul_template::manage_group) {
+    group { $consul_template::manage_group:
       ensure => 'present',
     }
   }


### PR DESCRIPTION
- if '' returns true but you seem to assume false, therefore using !empty($var) is the better approach
- $consul_template::user/$consul_template::group are not defined since the exported resources have been removed and manage_user/manage_group have been introduced. Using them instead.
