### PR TITLE
Adding support for the consul-template 'max-stale' parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ set to 'package', its installed using the system package manager.
 - `consul_token` Default: ''. ACL token to use when querying consul
 - `consul_retry` Default: 10s. Time in seconds to wait before retrying consul requests
 - `consul_wait` Default: undef. Min:Max time to wait before consul-template renders a new template to disk and triggers refresh. Specified in the format min:max according to [Go time duration format](http://golang.org/pkg/time/#ParseDuration)
-- `consul_max_stale` Default: 1s. The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader.
+- `consul_max_stale` Default: undef. The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader.
 - `init_style` Init style to use for consul-template service.
 - `log_level` Default: info. Logging level to use for consul-template service. Can be 'debug', 'warn', 'err', 'info'
 

--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,7 @@ set to 'package', its installed using the system package manager.
 - `consul_token` Default: ''. ACL token to use when querying consul
 - `consul_retry` Default: 10s. Time in seconds to wait before retrying consul requests
 - `consul_wait` Default: undef. Min:Max time to wait before consul-template renders a new template to disk and triggers refresh. Specified in the format min:max according to [Go time duration format](http://golang.org/pkg/time/#ParseDuration)
+- `consul_max_stale` Default: 1s. The maximum staleness of a query. If specified, Consul will distribute work among all servers instead of just the leader.
 - `init_style` Init style to use for consul-template service.
 - `log_level` Default: info. Logging level to use for consul-template service. Can be 'debug', 'warn', 'err', 'info'
 
@@ -46,10 +47,11 @@ include consul_template
 Or to specify parameters:
 ```puppet
 class { 'consul_template':
-    service_enable => false
-    log_level      => 'debug',
-    init_style     => 'upstart',
-    consul_wait    => '5s:30s'
+    service_enable   => false
+    log_level        => 'debug',
+    init_style       => 'upstart',
+    consul_wait      => '5s:30s',
+    consul_max_stale => '1s'
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,28 +32,37 @@ class consul_template::config (
     }
   }
 
+  # Set max-stale param if specified
+  if $::consul_template::consul_max_stale {
+    concat::fragment { 'consul_max_stale':
+      target  => 'consul-template/config.json',
+      content => inline_template("max-stale = \"${::consul_template::consul_max_stale}\"\n\n"),
+      order   => '03',
+    }
+  }
+
   if $::consul_template::vault_enabled {
     concat::fragment { 'vault-base':
       target  => 'consul-template/config.json',
       content => inline_template("vault {\n  address = \"${::consul_template::vault_address}\"\n  token = \"${::consul_template::vault_token}\"\n"),
-      order   => '03',
+      order   => '04',
     }
     if $::consul_template::vault_ssl {
       concat::fragment { 'vault-ssl1':
         target  => 'consul-template/config.json',
         content => inline_template("  ssl {\n    enabled = true\n    verify = ${::consul_template::vault_ssl_verify}\n"),
-        order   => '04',
+        order   => '05',
       }
       concat::fragment { 'vault-ssl2':
         target  => 'consul-template/config.json',
         content => inline_template("    cert = \"${::consul_template::vault_ssl_cert}\"\n    ca_cert = \"${::consul_template::vault_ssl_ca_cert}\"\n  }\n"),
-        order   => '05',
+        order   => '06',
       }
     }
     concat::fragment { 'vault-baseclose':
       target  => 'consul-template/config.json',
       content => "}\n\n",
-      order   => '06',
+      order   => '07',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class consul_template (
   $consul_token      = '',
   $consul_retry      = '10s',
   $consul_wait       = undef,
+  $consul_max_stale  = undef,
   $init_style        = $consul_template::params::init_style,
   $log_level         = $consul_template::params::log_level,
   $vault_enabled     = false,


### PR DESCRIPTION
This is an optional parameter you can pass to the puppet module. I just followed the consul_wait example when adding this. Ping me if you have any problems with it.
