### PR TITLE
Auto upgrade

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@
 - `purge_config_dir` **Default**: true. If enabled, removes config files no longer managed by Puppet.
 - `bin_dir` **Default**: /usr/local/bin. Path to the consul-template binaries
 - `arch` **Default**: Read from facter. System architecture to use (amd64, x86_64, i386)
-- `version` **Default**: 0.6.0. Version of consul-template to install
+- `version` **Default**: 0.11.0. Version of consul-template to install
 - `install_method` **Default**: url. When set to 'url', consul-template is downloaded and installed from source. If
 set to 'package', its installed using the system package manager.
 - `os` **Default**: Read from facter.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class consul_template (
   $version           = $consul_template::params::version,
   $install_method    = $consul_template::params::install_method,
   $os                = $consul_template::params::os,
-  $download_url      = "https://github.com/hashicorp/consul-template/releases/download/v${version}/consul_template_${version}_${os}_${arch}.tar.gz",
+  $download_url      = "https://github.com/hashicorp/consul-template/releases/download/v${version}/consul_template_${version}_${os}_${arch}.zip",
   $package_name      = $consul_template::params::package_name,
   $package_ensure    = $consul_template::params::package_ensure,
   $config_dir        = '/etc/consul-template',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class consul_template (
   $version           = $consul_template::params::version,
   $install_method    = $consul_template::params::install_method,
   $os                = $consul_template::params::os,
-  $download_url      = "https://github.com/hashicorp/consul-template/releases/download/v${version}/consul-template_${version}_${os}_${arch}.tar.gz",
+  $download_url      = "https://github.com/hashicorp/consul-template/releases/download/v${version}/consul_template_${version}_${os}_${arch}.tar.gz",
   $package_name      = $consul_template::params::package_name,
   $package_ensure    = $consul_template::params::package_ensure,
   $config_dir        = '/etc/consul-template',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,17 +16,20 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { 'consul-template.zip':
+    staging::file { "consul-template-${consul_template::version}.zip":
       source => $consul_template::download_url
     } ->
-    staging::extract { 'consul-template.zip':
-      target  => $consul_template::bin_dir,
-      creates => "${consul_template::bin_dir}/consul-template",
-    } ->
-    file {"${consul_template::bin_dir}/consul-template":
-            owner => 'root',
-            group => 0, # 0 instead of root because OS X uses "wheel".
-            mode  => '0555';
+    staging::extract { "consul-template-${consul_template::version}.zip":
+      target  => "${staging::path}/consul-template-${consul_template::version}",
+      creates => "${staging::path}/consul-template-${consul_template::version}/consul-template";
+    } -> file {
+      "${staging::path}/consul-template-${consul_template::version}/consul-template":
+        owner => 'root',
+        group => 0, # 0 instead of root because OS X uses "wheel".
+        mode  => '0555';
+      "${consul_template::bin_dir}/consul-template":
+        ensure => link,
+        target => "${staging::path}/consul-template-${consul_template::version}/consul-template";
     }
 
   } elsif $consul_template::install_method == 'package' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,17 +19,19 @@ class consul_template::install {
     staging::file { "consul-template-${consul_template::version}.zip":
       source => $consul_template::download_url
     } ->
-    staging::extract { "consul-template-${consul_template::version}.zip":
-      target  => "${staging::path}/consul-template-${consul_template::version}",
-      creates => "${staging::path}/consul-template-${consul_template::version}/consul-template";
+    file { "${::staging::path}/consul-template-${consul_template::version}":
+        ensure => directory,
+    } -> staging::extract { "consul-template-${consul_template::version}.zip":
+      target  => "${::staging::path}/consul-template-${consul_template::version}",
+      creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template";
     } -> file {
-      "${staging::path}/consul-template-${consul_template::version}/consul-template":
+      "${::staging::path}/consul-template-${consul_template::version}/consul-template":
         owner => 'root',
         group => 0, # 0 instead of root because OS X uses "wheel".
         mode  => '0555';
       "${consul_template::bin_dir}/consul-template":
         ensure => link,
-        target => "${staging::path}/consul-template-${consul_template::version}/consul-template";
+        target => "${::staging::path}/consul-template-${consul_template::version}/consul-template";
     }
 
   } elsif $consul_template::install_method == 'package' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,7 +22,6 @@ class consul_template::install {
     staging::extract { "consul-template-${consul_template::version}.zip":
       target  => $consul_template::bin_dir,
       creates => "${consul_template::bin_dir}/consul-template-${consul_template::version}",
-      strip   => 1,
     } ->
     file {
         "${consul_template::bin_dir}/consul-template":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,18 +16,23 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { 'consul-template.tar.gz':
+    staging::file { "consul-template-${consul_template::version}.tar.gz":
       source => $consul_template::download_url
     } ->
-    staging::extract { 'consul-template.tar.gz':
+    staging::extract { "consul-template-${consul_template::version}.tar.gz":
       target  => $consul_template::bin_dir,
-      creates => "${consul_template::bin_dir}/consul-template",
+      creates => "${consul_template::bin_dir}/consul-template-${consul_template::version}",
       strip   => 1,
     } ->
-    file { "${consul_template::bin_dir}/consul-template":
-      owner => 'root',
-      group => 0, # 0 instead of root because OS X uses "wheel".
-      mode  => '0555',
+    file {
+        "${consul_template::bin_dir}/consul-template":
+            ensure => link,
+            target => "${consul_template::bin_dir}/consul-template$-{consul_template::version}";
+
+        "${consul_template::bin_dir}/consul-template$-{consul_template::version}":
+            owner => 'root',
+            group => 0, # 0 instead of root because OS X uses "wheel".
+            mode  => '0555';
     }
 
   } elsif $consul_template::install_method == 'package' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,10 +16,10 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template-${consul_template::version}.tar.gz":
+    staging::file { "consul-template-${consul_template::version}.zip":
       source => $consul_template::download_url
     } ->
-    staging::extract { "consul-template-${consul_template::version}.tar.gz":
+    staging::extract { "consul-template-${consul_template::version}.zip":
       target  => $consul_template::bin_dir,
       creates => "${consul_template::bin_dir}/consul-template-${consul_template::version}",
       strip   => 1,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,19 +16,14 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template-${consul_template::version}.zip":
+    staging::file { 'consul-template.zip':
       source => $consul_template::download_url
     } ->
-    staging::extract { "consul-template-${consul_template::version}.zip":
+    staging::extract { 'consul-template.zip':
       target  => $consul_template::bin_dir,
-      creates => "${consul_template::bin_dir}/consul-template-${consul_template::version}",
+      creates => "${consul_template::bin_dir}/consul-template",
     } ->
-    file {
-        "${consul_template::bin_dir}/consul-template":
-            ensure => link,
-            target => "${consul_template::bin_dir}/consul-template$-{consul_template::version}";
-
-        "${consul_template::bin_dir}/consul-template$-{consul_template::version}":
+    file {"${consul_template::bin_dir}/consul-template":
             owner => 'root',
             group => 0, # 0 instead of root because OS X uses "wheel".
             mode  => '0555';

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,9 +13,7 @@ class consul_template::install {
 
   if $consul_template::install_method == 'url' {
 
-    if $::operatingsystem != 'darwin' {
-      ensure_packages(['tar'])
-    }
+    include staging
     staging::file { "consul-template-${consul_template::version}.zip":
       source => $consul_template::download_url
     } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class consul_template::params {
   $log_level         = 'info'
   $package_name      = 'consul-template'
   $package_ensure    = 'latest'
-  $version = '0.6.0'
+  $version = '0.11.0'
 
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }


### PR DESCRIPTION
Following changes let Puppet download a new release and installs the binary when the version variable has been changed. Furthermore, since release 0.11.0 consul-template comes as zip rather than a tar.gz, so I changed download url and how to extract it.
