### PR TITLE
Install new version when consul_template::version changes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,21 +13,29 @@ class consul_template::install {
 
   if $consul_template::install_method == 'url' {
 
+    include staging
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template.${consul_template::download_extension}":
+    staging::file { "consul-template_${consul_template::version}.${consul_template::download_extension}":
       source => $consul_template::real_download_url,
     } ->
-    staging::extract { "consul-template.${consul_template::download_extension}":
-      target  => $consul_template::bin_dir,
-      creates => "${consul_template::bin_dir}/consul-template",
+    file { "${::staging::path}/consul-template-${consul_template::version}":
+      ensure => directory,
+    } ->
+    staging::extract { "consul-template_${consul_template::version}.${consul_template::download_extension}":
+      target  => "${::staging::path}/consul-template-${consul_template::version}",
+      creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template",
       strip   => 1,
     } ->
-    file { "${consul_template::bin_dir}/consul-template":
-      owner => 'root',
-      group => 0, # 0 instead of root because OS X uses "wheel".
-      mode  => '0555',
+    file {
+      "${::staging::path}/consul-template-${consul_template::version}/consul-template":
+        owner => 'root',
+        group => 0, # 0 instead of root because OS X uses "wheel".
+        mode  => '0555';
+      "${consul_template::bin_dir}/consul-template":
+        ensure => link,
+        target => "${::staging::path}/consul-template-${consul_template::version}/consul-template";
     }
 
   } elsif $consul_template::install_method == 'package' {


### PR DESCRIPTION
Following changes let Puppet download a new release and installs the binary when the version variable has been changed.
