### PR TITLE
Resolve 'Cannot reassign variable download_extension' issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,8 @@ class consul_template (
   validate_bool($purge_config_dir)
 
   if versioncmp($version, '0.11.0') >= 0 {
-    $real_download_filename  = $download_extension
+    $download_filename  = 'consul_template'
+    $real_download_extension = $download_extension
   } else {
     $download_filename  = 'consul-template'
     $real_download_extension = 'tar.gz'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,13 +94,13 @@ class consul_template (
   validate_bool($purge_config_dir)
 
   if versioncmp($version, '0.11.0') >= 0 {
-    $download_filename  = 'consul_template'
+    $real_download_filename  = $download_extension
   } else {
     $download_filename  = 'consul-template'
-    $download_extension = 'tar.gz'
+    $real_download_extension = 'tar.gz'
   }
 
-  $real_download_url = pick($download_url, "${download_url_base}v${version}/${download_filename}_${version}_${os}_${arch}.${download_extension}")
+  $real_download_url = pick($download_url, "${download_url_base}v${version}/${download_filename}_${version}_${os}_${arch}.${real_download_extension}")
 
   class { '::consul_template::install': } ->
   class { '::consul_template::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,13 +17,13 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template_${consul_template::version}.${consul_template::download_extension}":
+    staging::file { "consul-template_${consul_template::version}.${consul_template::real_download_extension}":
       source => $consul_template::real_download_url,
     } ->
     file { "${::staging::path}/consul-template-${consul_template::version}":
       ensure => directory,
     } ->
-    staging::extract { "consul-template_${consul_template::version}.${consul_template::download_extension}":
+    staging::extract { "consul-template_${consul_template::version}.${consul_template::real_download_extension}":
       target  => "${::staging::path}/consul-template-${consul_template::version}",
       creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template",
       strip   => 1,

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -21,6 +21,20 @@ describe 'consul_template', :type => :class do
 
         it { is_expected.to contain_service('consul-template') }
       end
+      describe "Pin the version to an older release" do
+        let(:params) {{
+          'version' => '0.9.0',
+        }}
+        let(:facts) {{
+          :osfamily       => osfamily,
+          :concat_basedir => '/foo',
+          :path           => '/bin:/sbin:/usr/bin:/usr/sbin',
+          :architecture   => 'x86_64'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+
+      end
     end
   end
 end

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -33,6 +33,7 @@ describe 'consul_template', :type => :class do
         }}
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_staging__extract('consul-template_0.9.0.tar.gz') }
 
       end
     end


### PR DESCRIPTION
Addresses #38 - use `real_download_extension` instead of existing `download_extension` variable
