### PR TITLE
Switch install to use new releases.hashicorp.com download URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,16 +92,7 @@ class consul_template (
 ) inherits ::consul_template::params {
 
   validate_bool($purge_config_dir)
-
-  if versioncmp($version, '0.11.0') >= 0 {
-    $download_filename  = 'consul_template'
-    $real_download_extension = $download_extension
-  } else {
-    $download_filename  = 'consul-template'
-    $real_download_extension = 'tar.gz'
-  }
-
-  $real_download_url = pick($download_url, "${download_url_base}v${version}/${download_filename}_${version}_${os}_${arch}.${real_download_extension}")
+  $real_download_url = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
 
   class { '::consul_template::install': } ->
   class { '::consul_template::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,13 +17,13 @@ class consul_template::install {
     if $::operatingsystem != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template_${consul_template::version}.${consul_template::real_download_extension}":
+    staging::file { "consul-template_${consul_template::version}.${consul_template::download_extension}":
       source => $consul_template::real_download_url,
     } ->
     file { "${::staging::path}/consul-template-${consul_template::version}":
       ensure => directory,
     } ->
-    staging::extract { "consul-template_${consul_template::version}.${consul_template::real_download_extension}":
+    staging::extract { "consul-template_${consul_template::version}.${consul_template::download_extension}":
       target  => "${::staging::path}/consul-template-${consul_template::version}",
       creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template",
       strip   => 1,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class consul_template::params {
   $package_name       = 'consul-template'
   $package_ensure     = 'latest'
   $version            = '0.11.0'
-  $download_url_base  = 'https://github.com/hashicorp/consul-template/releases/download/'
+  $download_url_base  = 'https://releases.hashicorp.com/consul-template/'
   $download_extension = 'zip'
 
   case $::architecture {


### PR DESCRIPTION
The new official way to get hashicorp project binaries is now from https://releases.hashicorp.com. Updated the consul_template installer to use this new URL, and removed the special cases (for the github releases)
