### PR TITLE
Logrotation for consul-template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,10 @@ class consul_template (
   $consul_max_stale   = undef,
   $init_style         = $consul_template::params::init_style,
   $log_level          = $consul_template::params::log_level,
+  $logrotate_compress = 'nocompress',
+  $logrotate_files    = 4,
+  $logrotate_on       = false,
+  $logrotate_period   = 'daily',
   $vault_enabled      = false,
   $vault_address      = '',
   $vault_token        = '',
@@ -121,4 +125,11 @@ class consul_template (
   } ~>
   class { '::consul_template::service': } ->
   Class['::consul_template']
+  
+  class { '::consul_template::logrotate':
+    logrotate_compress => $logrotate_compress,
+    logrotate_files    => $logrotate_files,
+    logrotate_on       => $logrotate_on,
+    logrotate_period   => $logrotate_period,
+  }
 }


### PR DESCRIPTION
Usage example:
class { 'consul_template':
    log_level       => 'debug',
    consul_wait  => '5s:30s',
    logrotate_on => true,
    logrotate_compress => 'nocompress',
    logrotate_files    => 4,
    logrotate_period   => 'daily',
  }
It will create /etc/logrotate.d/consul-template with default content:
/var/log/consul-template.log{
    daily
    minsize 1M
    missingok
    dateext
    rotate 4
    nocompress
    create 644 root root
    postrotate
        /sbin/service consul-template restart 2> /dev/null || true
    endscript
}
