### PR TITLE
When using upstart run service as module user

### DIFF
--- a/templates/consul-template.upstart.erb
+++ b/templates/consul-template.upstart.erb
@@ -11,6 +11,9 @@ script
     exec $CONSUL -config $CONFIG/config <%= scope.lookupvar('consul_template::extra_options') %>
 end script
 
+setuid <%= scope.lookupvar('consul_template::user') %>
+setgid <%= scope.lookupvar('consul_template::group') %>
+
 respawn
 respawn limit 10 10
 kill timeout 10


### PR DESCRIPTION
Service was running as root by default. This may be backwards incompatible
if the service tries to write to files it no longer has permissions to.

Signed-off-by: Konrad Scherer kmscherer@gmail.com
