### PR TITLE
Systemd service should run as configured user

### DIFF
--- a/templates/consul-template.systemd.erb
+++ b/templates/consul-template.systemd.erb
@@ -4,6 +4,8 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
+User=<%= scope.lookupvar('consul_template::user') %>
+Group=<%= scope.lookupvar('consul_template::group') %>
 ExecStart=<%= scope.lookupvar('consul_template::bin_dir') %>/consul-template \
   -config <%= scope.lookupvar('consul_template::config_dir') %>/config <%= scope.lookupvar('consul_template::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
The systemd service currently runs as root, ignoring the user and group parameters.
