### PR TITLE
Add extra anchor dependency on consul_template::logrotate inclusion

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,7 @@ class consul_template (
     logrotate_files    => $logrotate_files,
     logrotate_on       => $logrotate_on,
     logrotate_period   => $logrotate_period,
+    require            => Anchor['::consul_template::begin'],
     before             => Anchor['::consul_template::end'],
   }
 }


### PR DESCRIPTION
Minor fix that is unlikely to really impact anyone at all... but for the sake of correctness this should've been done in #62 
