### PR TITLE
Remove `strip` arg for extract, only for GNU tar

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,6 @@ class consul_template::install {
     staging::extract { "consul-template_${consul_template::version}.${consul_template::download_extension}":
       target  => "${::staging::path}/consul-template-${consul_template::version}",
       creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template",
-      strip   => 1,
     } ->
     file {
       "${::staging::path}/consul-template-${consul_template::version}/consul-template":


### PR DESCRIPTION
The `strip` arg is not supported for `zip` files, which is the only
current distribution format for consul_template. This bug is causing
warnings during our puppet runs.
