### PR TITLE
Require package on init script

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -43,6 +43,7 @@ class consul_template::install {
     package { $consul_template::package_name:
       ensure => $consul_template::package_ensure,
     }
+    $requires = Package[$consul_template::package_name]
 
   } else {
     fail("The provided install method ${consul_template::install_method} is invalid")
@@ -72,6 +73,7 @@ class consul_template::install {
           owner   => 'root',
           group   => 'root',
           content => template('consul_template/consul-template.systemd.erb'),
+          require => $requires
         }
       }
       'sysv' : {
@@ -79,7 +81,8 @@ class consul_template::install {
           mode    => '0555',
           owner   => 'root',
           group   => 'root',
-          content => template('consul_template/consul-template.sysv.erb')
+          content => template('consul_template/consul-template.sysv.erb'),
+          require => $requires
         }
       }
       'debian' : {
@@ -87,7 +90,8 @@ class consul_template::install {
           mode    => '0555',
           owner   => 'root',
           group   => 'root',
-          content => template('consul_template/consul-template.debian.erb')
+          content => template('consul_template/consul-template.debian.erb'),
+          require => $requires
         }
       }
       'sles' : {
@@ -95,7 +99,8 @@ class consul_template::install {
           mode    => '0555',
           owner   => 'root',
           group   => 'root',
-          content => template('consul_template/consul-template.sles.erb')
+          content => template('consul_template/consul-template.sles.erb'),
+          require => $requires
         }
       }
       default : {


### PR DESCRIPTION
because our package actually includes an init script - we should probably requre the package first.
