### PR TITLE
Remove quotes from deduplicate.enabled = true

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class consul_template::config (
   if $::consul_template::deduplicate {
     concat::fragment { 'dedup-base':
       target  => 'consul-template/config.json',
-      content => inline_template("deduplicate {\n  enabled = \"true\"\n"),
+      content => inline_template("deduplicate {\n  enabled = true\n"),
       order   => '04',
     }
 


### PR DESCRIPTION
Quoted the string true and consul-template doesn't like that. Sorry for the 2-nd round.
