### PR TITLE
[khdevel]

### DIFF
--- a/manifests/logrotate.pp
+++ b/manifests/logrotate.pp
@@ -45,7 +45,7 @@ class consul_template::logrotate(
       content => template("${module_name}/consul-template.logrotate.erb"),
       owner   => 'root',
       group   => 'root',
-      mode    => 0644,
+      mode    => '0644',
     }
   }
 

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -4,11 +4,11 @@
 # This is a single instance of a configuration file to watch
 # for changes in Consul and update the local file
 define consul_template::watch (
+  $command,
+  $destination,
   $template = undef,
   $template_vars = {},
   $source = undef,
-  $destination,
-  $command,
 ) {
   include consul_template
 
@@ -35,12 +35,12 @@ define consul_template::watch (
   if $source != undef {
     $source_name = $source
     $frag_name   = $source
-  } else {  
+  } else {
     $source_name = "${consul_template::config_dir}/${name}.ctmpl"
     $frag_name   = "${name}.ctmpl"
   }
 
-  concat::fragment { "${frag_name}":
+  concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
     content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n}\n\n",
     order   => '10',

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -6,9 +6,9 @@
 define consul_template::watch (
   $command,
   $destination,
-  $template = undef,
+  $source        = undef,
+  $template      = undef,
   $template_vars = {},
-  $source = undef,
 ) {
   include consul_template
 


### PR DESCRIPTION
- corrections after puppet-lint syntax checker
- below messages were covered in this fix:

./manifests/watch.pp - WARNING: optional parameter listed before required parameter on line 10
./manifests/watch.pp - WARNING: optional parameter listed before required parameter on line 11
./manifests/watch.pp - WARNING: string containing only a variable on line 43
./manifests/watch.pp - ERROR: trailing whitespace found on line 38
./manifests/logrotate.pp - WARNING: unquoted file mode on line 48

```
modified:   manifests/logrotate.pp
modified:   manifests/watch.pp
```
