### PR TITLE
[WIP] Rework consul_template::watch to take config_hash

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -60,9 +60,10 @@ define consul_template::watch (
     }
   }
 
+  $content = consul_sorted_json($config_hash_real, $consul::pretty_config, $consul::pretty_config_indent)
   concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
-    content => consul_sorted_json({ template => $config_hash_real }, $consul::pretty_config, $consul::pretty_config_indent),
+    content => "template ${content}",
     order   => '10',
     notify  => Service['consul-template']
   }

--- a/spec/defines/watch_spec.rb
+++ b/spec/defines/watch_spec.rb
@@ -25,7 +25,41 @@ describe 'consul_template::watch', :type => :define do
       end
     end
   end
-  context 'Setting template and template_vars' do
+
+  context 'Setting template and template_vars (as config_hash)' do
+    ['Debian', 'RedHat'].each do |osfamily|
+      describe "consul_template::watch define on OS family #{osfamily}" do
+        let(:title) { 'test_watcher' }
+        let(:params) {{
+          :template => 'consul_template_spec/test_template',
+          :template_vars => { 'foo' => 'bar' },
+          :config_hash => {
+            :destination => '/var/tmp/consul_template',
+            :command => '/bin/test',
+            :wait => '2s:6s',
+          }
+        }}
+        let(:facts) {{
+          :osfamily       => osfamily,
+          :concat_basedir => '/foo',
+          :path           => '/bin:/sbin:/usr/bin:/usr/sbin',
+          :architecture   => 'x86_64'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_file('/etc/consul-template/test_watcher.ctmpl').with(
+            :content => /^bar$/,
+        )}
+        it { is_expected.to contain_concat__fragment('test_watcher.ctmpl').with(
+            :content => /wait/,
+        )}
+
+      end
+    end
+  end
+
+  context 'Setting template and template_vars (as deprecated params)' do
     ['Debian', 'RedHat'].each do |osfamily|
       describe "consul_template::watch define on OS family #{osfamily}" do
         let(:title) { 'test_watcher' }


### PR DESCRIPTION
This maintains backwards compatibility with the named params, but defaults their values to undef. All of the validations and behaviors have been maintained. The advantage of this approach is that arbitrary configuration can be passed through to the config file similar to how the consul module works. This way each new param doesn't have to be individually added before the module will support it, requiring PR's & releases, and updates to use them.

I plan to look at doing the same sort of thing with the consul_template config as well if it's of interest. I wanted to push this up so it'd be easier to see what I was after before doing that as it'll be quite a bit more involved with the way all that is set up. I hopefully can maintain backwards compatibility there as well. Thoughts?
