### PR TITLE
Update watch.pp

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -43,7 +43,7 @@ define consul_template::watch (
   concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
     content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n}\n\n",
-    order   => '10',
+    order   => '99',
     notify  => Service['consul-template']
   }
 }


### PR DESCRIPTION
Increase order for watch fragment.  When enabling vault, the closing brace comes after the watches fragments  and breaks consul-template.
