### PR TITLE
Update config to latest consult_template 0.18.2

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -88,6 +88,15 @@ class consul_template::config (
     }
   }
 
+  # Set syslog param if specified
+  if $::consul_template::syslog_enabled {
+    concat::fragment { 'syslog':
+      target  => 'consul-template/config.json',
+      content => inline_template("syslog {\n  enabled = true\n  facility = \"${::consul_template::syslog_facility}\"\n}\n\n"),
+      order   => '11',
+    }
+  }
+
   file { [$consul_template::config_dir, "${consul_template::config_dir}/config"]:
     ensure  => 'directory',
     purge   => $purge,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ class consul_template::config (
 
   concat::fragment { 'header':
     target  => 'consul-template/config.json',
-    content => inline_template("consul = \"<%= @consul_host %>:<%= @consul_port %>\"\ntoken = \"<%= @consul_token %>\"\nretry = \"<%= @consul_retry %>\"\n\n"),
+    content => inline_template("consul {\n  address = \"<%= @consul_host %>:<%= @consul_port %>\"\n  token = \"<%= @consul_token %>\"\n  retry = {\n    enabled = true\n    attempts = 5\n    backoff = \"<%= @consul_retry %>\"\n  }\n}\n\n"),
     order   => '00',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,8 @@ class consul_template (
   $logrotate_files    = 4,
   $logrotate_on       = false,
   $logrotate_period   = 'daily',
+  $syslog_enabled     = false,
+  $syslog_facility    = 'DAEMON',
   $vault_enabled      = false,
   $vault_address      = '',
   $vault_token        = '',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class consul_template::params {
   $log_level          = 'info'
   $package_name       = 'consul-template'
   $package_ensure     = 'latest'
-  $version            = '0.18.0'
+  $version            = '0.18.1'
   $download_url_base  = 'https://releases.hashicorp.com/consul-template/'
   $download_extension = 'zip'
   $user               = 'root'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class consul_template::params {
   $log_level          = 'info'
   $package_name       = 'consul-template'
   $package_ensure     = 'latest'
-  $version            = '0.11.0'
+  $version            = '0.18.0'
   $download_url_base  = 'https://releases.hashicorp.com/consul-template/'
   $download_extension = 'zip'
   $user               = 'root'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class consul_template::params {
   $log_level          = 'info'
   $package_name       = 'consul-template'
   $package_ensure     = 'latest'
-  $version            = '0.18.1'
+  $version            = '0.18.2'
   $download_url_base  = 'https://releases.hashicorp.com/consul-template/'
   $download_extension = 'zip'
   $user               = 'root'

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -43,7 +43,7 @@ define consul_template::watch (
   concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
     content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n}\n\n",
-    order   => '10',
+    order   => '20',
     notify  => Service['consul-template']
   }
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -10,6 +10,9 @@ define consul_template::watch (
   $template      = undef,
   $template_vars = {},
   $perms = '0644',
+  $command_timeout = '30s',
+  $backup = false,
+  $wait = undef
 ) {
   include consul_template
 
@@ -41,9 +44,15 @@ define consul_template::watch (
     $frag_name   = "${name}.ctmpl"
   }
 
+  if $wait != undef {
+    $fragment_wait = "  wait = \"${wait}\"\n"
+  } else {
+    $fragment_wait = ''
+  }
+
   concat::fragment { $frag_name:
     target  => 'consul-template/config.json',
-    content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n  perms = ${perms}\n}\n\n",
+    content => "template {\n  source = \"${source_name}\"\n  destination = \"${destination}\"\n  command = \"${command}\"\n  perms = ${perms}\n  backup = ${backup}\n  command_timeout = \"${command_timeout}\"\n${fragment_wait}}\n\n",
     order   => '20',
     notify  => Service['consul-template']
   }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -9,6 +9,7 @@ define consul_template::watch (
   $source        = undef,
   $template      = undef,
   $template_vars = {},
+  $perms = '0644',
 ) {
   include consul_template
 


### PR DESCRIPTION
The new config file format is backward-incompatible, and old format will prevent current consul_template from starting.

I just adapted the current parameters so they fit the new format, didn't took too much consideration on keeping backward compatibility.