### PR TITLE
Switch from %{linenumber} to %{line} in puppet-lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Rake::Task[:lint].clear
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.


### PR DESCRIPTION
linenumber was deprecated since puppet-lint 1.0, and removed in a puppet-lint 2.x release