### PR TITLE
changed from staging module to archive module for url installation method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@
 #   What is the path to the ca cert.pem
 #
 # [*data_dir*]
-#   Path to a directory to create to hold some data. Defaults to ''
+#   Path to a directory to create to hold some data. Defaults to '/opt/consul-template'
 #
 # [*user*]
 #   Name of a user to use for dir and file perms. Defaults to root.
@@ -70,7 +70,6 @@
 class consul_template (
   $purge_config_dir   = true,
   $config_mode        = $consul_template::params::config_mode,
-  $bin_dir            = '/usr/local/bin',
   $arch               = $consul_template::params::arch,
   $version            = $consul_template::params::version,
   $install_method     = $consul_template::params::install_method,
@@ -105,7 +104,7 @@ class consul_template (
   $vault_ssl_verify   = true,
   $vault_ssl_cert     = '',
   $vault_ssl_ca_cert  = '',
-  $data_dir           = '',
+  $data_dir           = $consul_template::params::data_dir,
   $user               = $consul_template::params::user,
   $group              = $consul_template::params::group,
   $manage_user        = $consul_template::params::manage_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,9 @@ class consul_template::params {
   $manage_user        = false
   $manage_group       = false
   $config_mode        = '0660'
+  $bin_dir            = '/usr/local/bin'
+  $archive_path       = ''
+  $data_dir           = '/opt/consul-template'
 
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class consul_template::params {
   $log_level          = 'info'
   $package_name       = 'consul-template'
   $package_ensure     = 'latest'
-  $version            = '0.11.0'
+  $version            = '0.19.0'
   $download_url_base  = 'https://releases.hashicorp.com/consul-template/'
   $download_extension = 'zip'
   $user               = 'root'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdhbashton-consul_template",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "author": "gdhbashton",
   "summary": "Install and manage Consul Template and its jobs",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0 < 5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.0 < 3.0.0" },
-    { "name": "puppet/staging", "version_requirement": ">= 0.4.0 <= 2.2.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.0 <= 3.0.0" },
+    { "name": "puppet/archive", "version_requirement": "<= 1.3.0" }
   ]
 }


### PR DESCRIPTION
We changed the the module from the dependcy nanliu/staging to puppet-archive, because it fits better in our control repository.
Maybe it is also useful for others.

Unfortunately I was not able to run all tests.