### PR TITLE
Breaking: drop older Puppet version support, add data types, other breaking changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :test do
   gem 'rake',                                                       :require => false
   gem 'puppet-lint',                                                :require => false
-  gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-alias-check',                                    :require => false
   gem 'puppet-lint-package_ensure-check',                           :require => false
   gem 'puppet-lint-legacy_facts-check',                             :require => false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,17 +3,22 @@
 # This class is called from consul_template for service config.
 #
 class consul_template::config (
-  $config_hash = {},
-  $purge       = true,
+  $config_hash           = $consul_template::config_hash,
+  $config_defaults       = $consul_template::config_defaults,
+  $purge                 = true,
 ) {
 
+  $config_base = {
+    consul => 'localhost:8500',
+  }
+  $_config_hash = deep_merge($config_base, $config_defaults, $config_hash)
+
   # Using our parent module's pretty_config & pretty_config_indent just because
-  $content_full = consul_sorted_json($config_hash, $consul_template::pretty_config, $consul_template::pretty_config_indent)
+  $content_full = consul_sorted_json($_config_hash, $consul_template::pretty_config, $consul_template::pretty_config_indent)
   # remove the closing } and it's surrounding newlines
   $content = regsubst($content_full, "\n}\n$", '')
 
   $concat_name = 'consul-template/config.json'
-
   concat::fragment { 'consul-service-pre':
     target  => $concat_name,
     # add the opening template array so that we can insert watch fragments
@@ -47,5 +52,5 @@ class consul_template::config (
     mode   => $consul_template::config_mode,
     notify => Service['consul-template'],
   }
-
 }
+

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,54 +2,54 @@
 #
 class consul_template::install {
 
-  if ! empty($::consul_template::data_dir) {
-    file { $::consul_template::data_dir:
+  if ! empty($consul_template::data_dir) {
+    file { $consul_template::data_dir:
       ensure => 'directory',
-      owner  => $::consul_template::user,
-      group  => $::consul_template::group,
+      owner  => $consul_template::user,
+      group  => $consul_template::group,
       mode   => '0755',
     }
   }
 
-  if $::consul_template::install_method == 'url' {
+  if $consul_template::install_method == 'url' {
 
-    include ::staging
-    if $::operatingsystem != 'darwin' {
+    include staging
+    if $facts['os']['name'] != 'darwin' {
       ensure_packages(['tar'])
     }
-    staging::file { "consul-template_${::consul_template::version}.${::consul_template::download_extension}":
-      source => $::consul_template::real_download_url,
+    staging::file { "consul-template_${consul_template::version}.${consul_template::download_extension}":
+      source => $consul_template::_download_url,
     }
-    -> file { "${::staging::path}/consul-template-${::consul_template::version}":
+    -> file { "${staging::path}/consul-template-${consul_template::version}":
       ensure => directory,
     }
-    -> staging::extract { "consul-template_${::consul_template::version}.${::consul_template::download_extension}":
-      target  => "${::staging::path}/consul-template-${consul_template::version}",
-      creates => "${::staging::path}/consul-template-${consul_template::version}/consul-template",
+    -> staging::extract { "consul-template_${consul_template::version}.${consul_template::download_extension}":
+      target  => "${staging::path}/consul-template-${consul_template::version}",
+      creates => "${staging::path}/consul-template-${consul_template::version}/consul-template",
     }
     -> file {
-      "${::staging::path}/consul-template-${::consul_template::version}/consul-template":
+      "${staging::path}/consul-template-${consul_template::version}/consul-template":
         owner => 'root',
         group => 0, # 0 instead of root because OS X uses "wheel".
         mode  => '0555';
-      "${::consul_template::bin_dir}/consul-template":
+      "${consul_template::bin_dir}/consul-template":
         ensure => link,
-        target => "${::staging::path}/consul-template-${::consul_template::version}/consul-template";
+        target => "${staging::path}/consul-template-${consul_template::version}/consul-template";
     }
 
-  } elsif $::consul_template::install_method == 'package' {
+  } elsif $consul_template::install_method == 'package' {
 
-    package { $::consul_template::package_name:
-      ensure => $::consul_template::package_ensure,
+    package { $consul_template::package_name:
+      ensure => $consul_template::package_ensure,
     }
 
   } else {
-    fail("The provided install method ${::consul_template::install_method} is invalid")
+    fail("The provided install method ${consul_template::install_method} is invalid")
   }
 
-  if $::consul_template::init_style {
+  if $consul_template::init_style {
 
-    case $::consul_template::init_style {
+    case $consul_template::init_style {
       'upstart' : {
         file { '/etc/init/consul-template.conf':
           mode    => '0444',
@@ -98,19 +98,19 @@ class consul_template::install {
         }
       }
       default : {
-        fail("I don't know how to create an init script for style ${::consul_template::init_style}")
+        fail("I don't know how to create an init script for style ${consul_template::init_style}")
       }
     }
   }
 
-  if $::consul_template::manage_user {
-    user { $::consul_template::user:
+  if $consul_template::manage_user {
+    user { $consul_template::user:
       ensure => 'present',
       system => true,
     }
   }
-  if $::consul_template::manage_group {
-    group { $::consul_template::group:
+  if $consul_template::manage_group {
+    group { $consul_template::group:
       ensure => 'present',
       system => true,
     }

--- a/manifests/logrotate.pp
+++ b/manifests/logrotate.pp
@@ -1,28 +1,22 @@
 # == Class consul_template::logrotate
 #
 class consul_template::logrotate(
-  $logrotate_compress,
-  $logrotate_files,
-  $logrotate_on,
-  $logrotate_period,
-  $restart_sysv = '/sbin/service consul-template restart',
-  $restart_systemd = '/bin/systemctl restart consul-template.service',
+  $logrotate_compress     = $consul_template::logrotate_compress,
+  $logrotate_files        = $consul_template::logrotate_files,
+  $logrotate_on           = $consul_template::logrotate_on,
+  $logrotate_period       = $consul_template::logrotate_period,
+  String $restart_sysv    = '/sbin/service consul-template restart',
+  String $restart_systemd = '/bin/systemctl restart consul-template.service',
 ) {
-  validate_string($logrotate_compress)
-  validate_integer($logrotate_files)
-  validate_bool($logrotate_on)
-  validate_string($logrotate_period)
-  validate_string($restart_sysv)
-  validate_string($restart_systemd)
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'RedHat', 'CentOS', 'OracleLinux', 'Scientific': {
-          if(versioncmp($::operatingsystemmajrelease, '7') > 0) {
+          if(versioncmp($facts['os']['release']['major'], '7') > 0) {
             $postrotate_command = $restart_systemd
           }
-          elsif (versioncmp($::operatingsystemmajrelease, '7') < 0) {
+          elsif (versioncmp($facts['os']['release']['major'], '7') < 0) {
             $postrotate_command = $restart_sysv
           }
           else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,9 +5,9 @@
 #
 class consul_template::params {
 
-  $os = downcase($::kernel)
+  $os = downcase($facts['kernel'])
 
-  case $::architecture {
+  case $facts['architecture'] {
     'x86_64', 'amd64': {
       $arch = 'amd64'
     }
@@ -16,31 +16,28 @@ class consul_template::params {
       $arch = '386'
     }
 
-    default: {
-      fail("Unsupported kernel architecture: ${::architecture}")
+    default:           {
+      fail("Unsupported kernel architecture: ${facts['architecture']}")
     }
   }
 
-  $init_style = $::operatingsystem ? {
-    'Ubuntu' => $::lsbdistrelease ? {
-      '8.04'  => 'debian',
+  $init_style = $facts['os']['name'] ? {
+    'Ubuntu' => $facts['os']['release']['major'] ? {
       '15.04' => 'systemd',
       '16.04' => 'systemd',
       default => 'upstart'
     },
 
-    /CentOS|RedHat/ => $::operatingsystemmajrelease ? {
-      /(4|5|6)/ => 'sysv',
+    /CentOS|RedHat/ => $facts['os']['release']['major'] ? {
+      '6' => 'sysv',
       default   => 'systemd',
     },
-
-    'Fedora'        => $::operatingsystemmajrelease ? {
+    'Fedora'        => $facts['os']['release']['major'] ? {
       /(12|13|14)/ => 'sysv',
       default      => 'systemd',
     },
-
-    'Debian'        =>  $::operatingsystemmajrelease ? {
-      /(4|5|6|7)/ => 'debian',
+    'Debian'        =>  $facts['os']['release']['major'] ? {
+      '7' => 'debian',
       default     => 'systemd'
     },
 

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -9,21 +9,21 @@ define consul_template::watch (
   $template        = undef,
   $template_vars   = {},
 ) {
-  include ::consul_template
+  include consul_template
 
-  $config_hash_real = deep_merge($config_defaults, $config_hash)
-  if $template == undef and $config_hash_real['source'] == undef {
+  $_config_hash = deep_merge($config_defaults, $config_hash)
+  if $template == undef and $_config_hash['source'] == undef {
     err ('Specify either template parameter or config_hash["source"] for consul_template::watch')
   }
 
-  if $template != undef and $config_hash_real['source'] != undef {
+  if $template != undef and $_config_hash['source'] != undef {
     err ('Specify either template parameter or config_hash["source"] for consul_template::watch - but not both')
   }
 
   unless $template {
     # source is specified in config_hash
     $config_source = {}
-    $frag_name = $config_hash_real['source']
+    $frag_name = $_config_hash['source']
     $fragment_requires = undef
   } else {
     # source is specified as a template
@@ -45,7 +45,7 @@ define consul_template::watch (
     $fragment_requires = File[$source]
   }
 
-  $config_hash_all = deep_merge($config_hash_real, $config_source)
+  $config_hash_all = deep_merge($_config_hash, $config_source)
   $content_full = consul_sorted_json($config_hash_all, $consul_template::pretty_config, $consul_template::pretty_config_indent)
   $content = regsubst(regsubst($content_full, "}\n$", '}'), "\n", "\n    ", 'G')
 

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,12 @@
   "source"                  : "https://github.com/claranet/puppet-consul_template",
   "project_page"            : "https://github.com/claranet/puppet-consul_template",
   "issues_url"              : "https://github.com/claranet/puppet-consul_template/issues",
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.1 < 6.0.0"
+    }
+  ],
   "operatingsystem_support" :  [
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "6.0", "7.0" ]},
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6.0", "7.0" ]},
@@ -14,7 +20,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease" : [ "14.04", "16.04" ]}
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.0.0 < 6.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.13.1 < 6.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.2.0 < 3.0.0" },
     { "name": "puppet/staging", "version_requirement": ">= 2.0.0 <= 3.0.0" },
     { "name": "KyleAnderson/consul", "version_requirement": ">= 3.2.3 < 4.0.0" }


### PR DESCRIPTION
This is backwards incompatible in multiple ways

- Drop support for Puppet < 4.7.1
- Require stdlib >= 4.13 
- Drop support for very old OSes like RHEL / CentOS 5, etc.

Additionally, we:
- restructure class inclusion by replacing anchor pattern with 'contain' and class ordering
- switch to data types from `validate_`. For now, I just added them to stuff that was super obvious and things that had `validate_` calls.
- rename $::foo to $foo (absolute classname check is not needed with newer Puppet) (sorry I didn't break these changes out into a separate commit)
- switch to structured facts
- move from `$foo_real` to `$_foo` pattern