### PR TITLE
Bump dependency of puppet-consul to 3.2.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,6 @@
     { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0 < 5.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.0.0 < 3.0.0" },
     { "name": "puppet/staging", "version_requirement": ">= 0.4.0 <= 2.2.0" },
-    { "name": "KyleAnderson/consul", "version_requirement": ">= 2.1.1" }
+    { "name": "KyleAnderson/consul", "version_requirement": ">= 3.2.2" }
   ]
 }


### PR DESCRIPTION
3.2.2 includes a consul_template relevant fix for rendering octal file modes to valid json. Details can be found in the following issue https://github.com/solarkennedy/puppet-consul/issues/389